### PR TITLE
feat: [P2-8] 建構賽季趨勢頁面

### DIFF
--- a/app/season-trends/page.css.ts
+++ b/app/season-trends/page.css.ts
@@ -1,0 +1,68 @@
+// /app/season-trends/page.css.ts
+
+import { style } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
+export const container = style({
+  maxWidth: '1200px',
+  margin: '0 auto',
+  padding: `${vars.space.lg} ${vars.space.md}`,
+  fontFamily: vars.fontFamily.body,
+})
+
+export const header = style({
+  display: 'flex',
+  flexWrap: 'wrap', // 允許換行以適應 RWD
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: vars.space.md,
+  marginBottom: vars.space.xl,
+})
+
+export const title = style({
+  fontSize: vars.fontSizes.xxl,
+  fontWeight: 600,
+  color: vars.colors.textPrimary,
+  marginRight: 'auto', // 讓標題佔據左側空間
+})
+
+export const controlsContainer = style({
+  display: 'flex',
+  gap: vars.space.md,
+  alignItems: 'center',
+})
+
+export const contentContainer = style({
+  display: 'grid',
+  gap: vars.space.xl,
+})
+
+export const loadingOrErrorState = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  minHeight: '400px',
+  fontSize: vars.fontSizes.lg,
+  color: vars.colors.textSecondary,
+})
+
+export const collapsibleTrigger = style({
+  width: '100%',
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  backgroundColor: vars.colors.surface,
+  border: `1px solid ${vars.colors.border}`,
+  borderRadius: '6px',
+  textAlign: 'left',
+  fontWeight: 500,
+  cursor: 'pointer',
+  marginTop: vars.space.xl,
+  selectors: {
+    '&:hover': {
+      backgroundColor: vars.colors.background,
+    },
+  },
+})
+
+export const collapsibleContent = style({
+  paddingTop: vars.space.md,
+})

--- a/app/season-trends/page.css.ts
+++ b/app/season-trends/page.css.ts
@@ -12,22 +12,37 @@ export const container = style({
 
 export const header = style({
   display: 'flex',
-  flexWrap: 'wrap', // 允許換行以適應 RWD
+  flexWrap: 'wrap',
   justifyContent: 'space-between',
   alignItems: 'center',
   gap: vars.space.md,
   marginBottom: vars.space.xl,
+
+  '@media': {
+    'screen and (max-width: 768px)': {
+      flexDirection: 'column',
+      alignItems: 'stretch', // 讓內容撐滿寬度
+    },
+  },
 })
 
 export const title = style({
   fontSize: vars.fontSizes.xxl,
   fontWeight: 600,
   color: vars.colors.textPrimary,
-  marginRight: 'auto', // 讓標題佔據左側空間
+  marginRight: 'auto',
+
+  '@media': {
+    'screen and (max-width: 768px)': {
+      marginRight: 0,
+      marginBottom: vars.space.md,
+    },
+  },
 })
 
 export const controlsContainer = style({
   display: 'flex',
+  flexWrap: 'wrap', // 允許控制器換行
   gap: vars.space.md,
   alignItems: 'center',
 })

--- a/app/season-trends/page.css.ts
+++ b/app/season-trends/page.css.ts
@@ -1,7 +1,35 @@
 // /app/season-trends/page.css.ts
 
-import { style } from '@vanilla-extract/css'
+import { style, keyframes } from '@vanilla-extract/css'
 import { vars } from '@/styles/theme.css'
+
+const spin = keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' },
+})
+
+export const dataDisplayContainer = style({
+  position: 'relative',
+})
+
+export const loadingOverlay = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(255, 255, 255, 0.7)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 10,
+  borderRadius: '8px',
+  transition: 'opacity 0.2s ease-in-out',
+})
+
+export const spinner = style({
+  animation: `${spin} 1s linear infinite`,
+})
 
 export const container = style({
   maxWidth: '1200px',
@@ -17,11 +45,10 @@ export const header = style({
   alignItems: 'center',
   gap: vars.space.md,
   marginBottom: vars.space.xl,
-
   '@media': {
     'screen and (max-width: 768px)': {
       flexDirection: 'column',
-      alignItems: 'stretch', // 讓內容撐滿寬度
+      alignItems: 'stretch',
     },
   },
 })
@@ -31,7 +58,6 @@ export const title = style({
   fontWeight: 600,
   color: vars.colors.textPrimary,
   marginRight: 'auto',
-
   '@media': {
     'screen and (max-width: 768px)': {
       marginRight: 0,
@@ -42,7 +68,7 @@ export const title = style({
 
 export const controlsContainer = style({
   display: 'flex',
-  flexWrap: 'wrap', // 允許控制器換行
+  flexWrap: 'wrap',
   gap: vars.space.md,
   alignItems: 'center',
 })

--- a/app/season-trends/page.tsx
+++ b/app/season-trends/page.tsx
@@ -62,7 +62,7 @@ const MetricSelector = ({
                 e.preventDefault()
                 handleSelect(metric.key)
               }}
-              style={{ paddingLeft: '2rem' }} // 預留空間給 Check 圖示
+              style={{ paddingLeft: '2rem' }}
             >
               {isSelected && <Check size={16} style={{ position: 'absolute', left: '0.5rem' }} />}
               {metric.label}
@@ -90,10 +90,15 @@ export default function SeasonTrendsPage() {
     dateRange,
   })
 
-  const currentPlayerStats = React.useMemo(
-    () => (data && selectedPlayer ? data[selectedPlayer] || [] : []),
-    [data, selectedPlayer]
-  )
+  const currentPlayerStats = React.useMemo(() => {
+    if (!data || !selectedPlayer) return []
+    const playerData = data[selectedPlayer] || []
+    return [...playerData].sort(
+      (a, b) =>
+        new Date(a.data_retrieved_date || 0).getTime() -
+        new Date(b.data_retrieved_date || 0).getTime()
+    )
+  }, [data, selectedPlayer])
 
   const activeChartMetrics = React.useMemo(
     () => PLAYER_STATS_METRICS.filter((metric) => selectedMetrics.includes(metric.key)),

--- a/app/season-trends/page.tsx
+++ b/app/season-trends/page.tsx
@@ -1,0 +1,172 @@
+// /app/season-trends/page.tsx
+
+'use client'
+
+import * as React from 'react'
+import { addDays } from 'date-fns'
+import { Check } from 'lucide-react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/DropdownMenu'
+import { Button } from '@/components/ui/Button'
+import { useGetPlayersSeasonStats } from '@/hooks/useGetPlayersSeasonStats'
+import { TRENDING_PLAYERS } from '@/lib/constants'
+import { PLAYER_STATS_METRICS } from '@/lib/configs/metrics'
+import { DateRangePicker } from '@/components/features/DateRangePicker'
+import { StatsTrendChart } from '@/components/features/StatsTrendChart'
+import { DataTable, ColumnDef } from '@/components/ui/DataTable'
+import * as styles from './page.css'
+import type { components } from '@/types/generated-api'
+
+type PlayerSeasonStatsHistory = components['schemas']['PlayerSeasonStatsHistory']
+
+// --- UI 控制器元件 ---
+const MetricSelector = ({
+  selectedMetrics,
+  onSelectionChange,
+}: {
+  selectedMetrics: string[]
+  onSelectionChange: (newSelection: string[]) => void
+}) => {
+  const handleSelect = (metricKey: string) => {
+    const newSelection = selectedMetrics.includes(metricKey)
+      ? selectedMetrics.filter((key) => key !== metricKey)
+      : [...selectedMetrics, metricKey]
+
+    if (newSelection.length > 3) {
+      return
+    }
+    onSelectionChange(newSelection)
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="secondary">選擇指標 ({selectedMetrics.length})</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>選擇最多3項指標</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {PLAYER_STATS_METRICS.map((metric) => {
+          const isSelected = selectedMetrics.includes(metric.key)
+          return (
+            <DropdownMenuItem
+              key={metric.key}
+              onSelect={(e: Event) => {
+                e.preventDefault()
+                handleSelect(metric.key)
+              }}
+              style={{ paddingLeft: '2rem' }} // 預留空間給 Check 圖示
+            >
+              {isSelected && <Check size={16} style={{ position: 'absolute', left: '0.5rem' }} />}
+              {metric.label}
+            </DropdownMenuItem>
+          )
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+// --- 主頁面元件 ---
+export default function SeasonTrendsPage() {
+  const [dateRange, setDateRange] = React.useState<{ start: Date; end: Date }>(() => {
+    const end = new Date()
+    const start = addDays(end, -29)
+    return { start, end }
+  })
+
+  const [selectedPlayer, setSelectedPlayer] = React.useState<string>(TRENDING_PLAYERS[0])
+  const [selectedMetrics, setSelectedMetrics] = React.useState<string[]>(['avg', 'ops'])
+
+  const { data, isLoading, isError, error } = useGetPlayersSeasonStats({
+    playerNames: TRENDING_PLAYERS,
+    dateRange,
+  })
+
+  const currentPlayerStats = React.useMemo(
+    () => (data && selectedPlayer ? data[selectedPlayer] || [] : []),
+    [data, selectedPlayer]
+  )
+
+  const activeChartMetrics = React.useMemo(
+    () => PLAYER_STATS_METRICS.filter((metric) => selectedMetrics.includes(metric.key)),
+    [selectedMetrics]
+  )
+
+  const tableColumns: ColumnDef<PlayerSeasonStatsHistory>[] = React.useMemo(
+    () => [
+      { accessorKey: 'data_retrieved_date', header: '日期' },
+      { accessorKey: 'hits', header: '安打' },
+      { accessorKey: 'at_bats', header: '打數' },
+      { accessorKey: 'homeruns', header: '全壘打' },
+      { accessorKey: 'rbi', header: '打點' },
+      { accessorKey: 'avg', header: '打擊率', cell: ({ row }) => row.avg?.toFixed(3) ?? '.000' },
+      { accessorKey: 'ops', header: '攻擊指數', cell: ({ row }) => row.ops?.toFixed(3) ?? '.000' },
+    ],
+    []
+  )
+
+  const renderContent = () => {
+    if (isLoading) return <div className={styles.loadingOrErrorState}>Loading...</div>
+    if (isError) {
+      return (
+        <div className={styles.loadingOrErrorState}>
+          Error: {error instanceof Error ? error.message : 'An unknown error occurred'}
+        </div>
+      )
+    }
+    if (data) {
+      return (
+        <div className={styles.contentContainer}>
+          <StatsTrendChart data={currentPlayerStats} metrics={activeChartMetrics} />
+
+          <Collapsible.Root>
+            <Collapsible.Trigger asChild>
+              <button className={styles.collapsibleTrigger}>顯示/隱藏 每日詳細數據</button>
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <div className={styles.collapsibleContent}>
+                <DataTable data={currentPlayerStats} columns={tableColumns} />
+              </div>
+            </Collapsible.Content>
+          </Collapsible.Root>
+        </div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>賽季趨勢</h1>
+        <div className={styles.controlsContainer}>
+          <select
+            value={selectedPlayer}
+            onChange={(e) => setSelectedPlayer(e.target.value)}
+            style={{ padding: '8px', borderRadius: '6px' }}
+          >
+            {TRENDING_PLAYERS.map((player) => (
+              <option key={player} value={player}>
+                {player}
+              </option>
+            ))}
+          </select>
+          <MetricSelector
+            selectedMetrics={selectedMetrics}
+            onSelectionChange={setSelectedMetrics}
+          />
+          <DateRangePicker onRangeChange={setDateRange} />
+        </div>
+      </header>
+      <main>{renderContent()}</main>
+    </div>
+  )
+}

--- a/app/season-trends/page.tsx
+++ b/app/season-trends/page.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react'
 import { addDays } from 'date-fns'
-import { Check } from 'lucide-react'
+import { Check, Loader2 } from 'lucide-react' // 導入 Loader2 圖示
 import * as Collapsible from '@radix-ui/react-collapsible'
 import {
   DropdownMenu,
@@ -85,7 +85,7 @@ export default function SeasonTrendsPage() {
   const [selectedPlayer, setSelectedPlayer] = React.useState<string>(TRENDING_PLAYERS[0])
   const [selectedMetrics, setSelectedMetrics] = React.useState<string[]>(['avg', 'ops'])
 
-  const { data, isLoading, isError, error } = useGetPlayersSeasonStats({
+  const { data, isLoading, isFetching, isError, error } = useGetPlayersSeasonStats({
     playerNames: TRENDING_PLAYERS,
     dateRange,
   })
@@ -119,7 +119,9 @@ export default function SeasonTrendsPage() {
   )
 
   const renderContent = () => {
+    // 僅在初次載入時顯示全螢幕 Loading
     if (isLoading) return <div className={styles.loadingOrErrorState}>Loading...</div>
+
     if (isError) {
       return (
         <div className={styles.loadingOrErrorState}>
@@ -127,24 +129,34 @@ export default function SeasonTrendsPage() {
         </div>
       )
     }
+
+    // 當有數據時，即使在背景更新 (isFetching) 中也繼續渲染內容
     if (data) {
       return (
-        <div className={styles.contentContainer}>
-          <StatsTrendChart data={currentPlayerStats} metrics={activeChartMetrics} />
-
-          <Collapsible.Root>
-            <Collapsible.Trigger asChild>
-              <button className={styles.collapsibleTrigger}>顯示/隱藏 每日詳細數據</button>
-            </Collapsible.Trigger>
-            <Collapsible.Content>
-              <div className={styles.collapsibleContent}>
-                <DataTable data={currentPlayerStats} columns={tableColumns} />
-              </div>
-            </Collapsible.Content>
-          </Collapsible.Root>
+        <div className={styles.dataDisplayContainer}>
+          {/* 當 isFetching 為 true 時，顯示載入遮罩 */}
+          {isFetching && (
+            <div className={styles.loadingOverlay}>
+              <Loader2 size={32} className={styles.spinner} />
+            </div>
+          )}
+          <div className={styles.contentContainer}>
+            <StatsTrendChart data={currentPlayerStats} metrics={activeChartMetrics} />
+            <Collapsible.Root>
+              <Collapsible.Trigger asChild>
+                <button className={styles.collapsibleTrigger}>顯示/隱藏 每日詳細數據</button>
+              </Collapsible.Trigger>
+              <Collapsible.Content>
+                <div className={styles.collapsibleContent}>
+                  <DataTable data={currentPlayerStats} columns={tableColumns} />
+                </div>
+              </Collapsible.Content>
+            </Collapsible.Root>
+          </div>
         </div>
       )
     }
+
     return null
   }
 

--- a/components/features/CumulativeStatsTable.css.ts
+++ b/components/features/CumulativeStatsTable.css.ts
@@ -1,0 +1,58 @@
+// /components/features/CumulativeStatsTable.css.ts
+
+import { style } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
+export const tableContainer = style({
+  overflowX: 'auto',
+  border: `1px solid ${vars.colors.border}`,
+  borderRadius: '8px',
+  backgroundColor: vars.colors.surface,
+})
+
+export const table = style({
+  width: '100%',
+  borderCollapse: 'collapse',
+  textAlign: 'left',
+  fontFamily: vars.fontFamily.body,
+})
+
+export const thead = style({
+  backgroundColor: vars.colors.background,
+  borderBottom: `1px solid ${vars.colors.border}`,
+})
+
+export const th = style({
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  fontWeight: 500,
+  fontSize: vars.fontSizes.sm,
+  color: vars.colors.textSecondary,
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+})
+
+export const tbody = style({})
+
+export const tr = style({
+  borderBottom: `1px solid ${vars.colors.border}`,
+  selectors: {
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+    '&:hover': {
+      backgroundColor: vars.colors.background,
+    },
+  },
+  transition: 'background-color 0.2s ease-in-out',
+})
+
+export const td = style({
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  fontSize: vars.fontSizes.base,
+  color: vars.colors.textPrimary,
+  verticalAlign: 'middle',
+})
+
+export const playerName = style({
+  fontWeight: 500,
+})

--- a/components/features/CumulativeStatsTable.tsx
+++ b/components/features/CumulativeStatsTable.tsx
@@ -1,0 +1,80 @@
+// /components/features/CumulativeStatsTable.tsx
+
+'use client'
+
+import * as React from 'react'
+import * as styles from './CumulativeStatsTable.css'
+import type { components } from '@/types/generated-api'
+
+// 從 generated-api.ts 導入的確切型別
+type PlayerSeasonStatsHistory = components['schemas']['PlayerSeasonStatsHistory']
+
+type CumulativeStatsTableProps = {
+  // data 的 key 是球員姓名
+  data: Record<string, PlayerSeasonStatsHistory[]>
+}
+
+type CalculatedStats = {
+  playerName: string
+  at_bats: number
+  hits: number
+  homeruns: number
+  rbi: number
+  avg: string
+}
+
+const calculateCumulativeStats = (data: CumulativeStatsTableProps['data']): CalculatedStats[] => {
+  return Object.entries(data).map(([playerName, statsHistory]) => {
+    const totals = statsHistory.reduce(
+      (acc, day) => {
+        acc.at_bats += day.at_bats || 0
+        acc.hits += day.hits || 0
+        acc.homeruns += day.homeruns || 0
+        acc.rbi += day.rbi || 0
+        return acc
+      },
+      { at_bats: 0, hits: 0, homeruns: 0, rbi: 0 }
+    )
+
+    const avg = totals.at_bats > 0 ? (totals.hits / totals.at_bats).toFixed(3).substring(1) : '.000'
+
+    return {
+      playerName,
+      ...totals,
+      avg,
+    }
+  })
+}
+
+export const CumulativeStatsTable: React.FC<CumulativeStatsTableProps> = ({ data }) => {
+  const calculatedData = React.useMemo(() => calculateCumulativeStats(data), [data])
+
+  return (
+    <div className={styles.tableContainer}>
+      <table className={styles.table}>
+        <thead className={styles.thead}>
+          <tr>
+            <th className={styles.th}>球員</th>
+            <th className={styles.th}>打數</th>
+            <th className={styles.th}>安打</th>
+            <th className={styles.th}>全壘打</th>
+            <th className={styles.th}>打點</th>
+            <th className={styles.th}>打擊率</th>
+          </tr>
+        </thead>
+        <tbody className={styles.tbody}>
+          {calculatedData.map((playerStats) => (
+            <tr key={playerStats.playerName} className={styles.tr}>
+              <td className={`${styles.td} ${styles.playerName}`}>{playerStats.playerName}</td>
+              <td className={styles.td}>{playerStats.at_bats}</td>
+              <td className={styles.td}>{playerStats.hits}</td>
+              <td className={styles.td}>{playerStats.homeruns}</td>
+              <td className={styles.td}>{playerStats.rbi}</td>
+              <td className={styles.td}>{playerStats.avg}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/components/features/DateRangePicker.css.ts
+++ b/components/features/DateRangePicker.css.ts
@@ -1,0 +1,57 @@
+// /components/features/DateRangePicker.css.ts
+
+import { style, globalStyle } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
+export const triggerButton = style({
+  width: '240px',
+  justifyContent: 'space-between',
+  textAlign: 'left',
+  fontWeight: 400,
+})
+
+export const calendarIcon = style({
+  marginLeft: vars.space.sm,
+  color: vars.colors.textSecondary,
+})
+
+// react-day-picker 的樣式覆蓋
+export const dayPicker = style({
+  backgroundColor: vars.colors.surface,
+  padding: vars.space.md,
+  borderRadius: '8px',
+  border: `1px solid ${vars.colors.border}`,
+})
+
+globalStyle(`${dayPicker} .rdp-caption_label`, {
+  fontFamily: vars.fontFamily.body,
+  fontSize: vars.fontSizes.base,
+  fontWeight: 500,
+  color: vars.colors.textPrimary,
+})
+
+globalStyle(`${dayPicker} .rdp-nav_button`, {
+  color: vars.colors.textPrimary,
+})
+
+globalStyle(`${dayPicker} .rdp-head_cell`, {
+  fontFamily: vars.fontFamily.body,
+  fontSize: vars.fontSizes.sm,
+  color: vars.colors.textSecondary,
+})
+
+globalStyle(`${dayPicker} .rdp-day`, {
+  fontFamily: vars.fontFamily.body,
+  color: vars.colors.textPrimary,
+  borderRadius: '6px',
+})
+
+globalStyle(`${dayPicker} .rdp-day_selected`, {
+  backgroundColor: `${vars.colors.primary} !important`,
+  color: `${vars.colors.surface} !important`,
+})
+
+globalStyle(`${dayPicker} .rdp-day_range_middle`, {
+  backgroundColor: vars.colors.background,
+  borderRadius: 0,
+})

--- a/components/features/DateRangePicker.tsx
+++ b/components/features/DateRangePicker.tsx
@@ -28,15 +28,14 @@ type Preset = '7d' | '30d' | 'season'
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({ onRangeChange }) => {
   const [label, setLabel] = React.useState('最近 30 天')
   const [popoverOpen, setPopoverOpen] = React.useState(false)
-  const [range, setRange] = React.useState<DateRange | undefined>(undefined)
-
-  React.useEffect(() => {
-    // 初始化預設值
+  const [range, setRange] = React.useState<DateRange | undefined>(() => {
+    // 內部狀態的初始化，與父元件同步
     const today = new Date()
     const start = addDays(today, -29)
-    onRangeChange({ start, end: today })
-    setRange({ from: start, to: today })
-  }, [onRangeChange])
+    return { from: start, to: today }
+  })
+
+  // 讓父元件全權負責初始狀態，子元件只負責響應使用者操作並通知父層
 
   const handlePresetSelect = (preset: Preset) => {
     const today = new Date()
@@ -49,7 +48,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ onRangeChange 
         newLabel = '最近 7 天'
         break
       case 'season':
-        start = startOfYear(today) // 假設賽季從年初開始
+        start = startOfYear(today)
         newLabel = '本賽季'
         break
       case '30d':
@@ -71,7 +70,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ onRangeChange 
       setLabel(
         `${format(selectedRange.from, 'yyyy-MM-dd')} ~ ${format(selectedRange.to, 'yyyy-MM-dd')}`
       )
-      setPopoverOpen(false) // 選擇完畢後關閉
+      setPopoverOpen(false)
     }
   }
 
@@ -90,7 +89,6 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({ onRangeChange 
           <DropdownMenuItem onSelect={() => handlePresetSelect('season')}>本賽季</DropdownMenuItem>
           <DropdownMenuSeparator />
           <Popover.Trigger asChild>
-            {/* onSelect 需 preventDefault 以免觸發 DropdownMenu 的關閉事件 */}
             <DropdownMenuItem onSelect={(e) => e.preventDefault()}>自訂範圍...</DropdownMenuItem>
           </Popover.Trigger>
         </DropdownMenuContent>

--- a/components/features/DateRangePicker.tsx
+++ b/components/features/DateRangePicker.tsx
@@ -1,0 +1,111 @@
+// /components/features/DateRangePicker.tsx
+
+'use client'
+
+import * as React from 'react'
+import { Calendar as CalendarIcon } from 'lucide-react'
+import { addDays, startOfYear, format } from 'date-fns'
+import { DateRange, DayPicker } from 'react-day-picker'
+import 'react-day-picker/dist/style.css' // 引入基礎樣式
+
+import * as Popover from '@radix-ui/react-popover'
+import { Button } from '@/components/ui/Button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+import * as styles from './DateRangePicker.css'
+
+type DateRangePickerProps = {
+  onRangeChange: (range: { start: Date; end: Date }) => void
+}
+
+type Preset = '7d' | '30d' | 'season'
+
+export const DateRangePicker: React.FC<DateRangePickerProps> = ({ onRangeChange }) => {
+  const [label, setLabel] = React.useState('最近 30 天')
+  const [popoverOpen, setPopoverOpen] = React.useState(false)
+  const [range, setRange] = React.useState<DateRange | undefined>(undefined)
+
+  React.useEffect(() => {
+    // 初始化預設值
+    const today = new Date()
+    const start = addDays(today, -29)
+    onRangeChange({ start, end: today })
+    setRange({ from: start, to: today })
+  }, [onRangeChange])
+
+  const handlePresetSelect = (preset: Preset) => {
+    const today = new Date()
+    let start: Date
+    let newLabel = ''
+
+    switch (preset) {
+      case '7d':
+        start = addDays(today, -6)
+        newLabel = '最近 7 天'
+        break
+      case 'season':
+        start = startOfYear(today) // 假設賽季從年初開始
+        newLabel = '本賽季'
+        break
+      case '30d':
+      default:
+        start = addDays(today, -29)
+        newLabel = '最近 30 天'
+        break
+    }
+
+    setRange({ from: start, to: today })
+    setLabel(newLabel)
+    onRangeChange({ start, end: today })
+  }
+
+  const handleCustomRangeSelect = (selectedRange: DateRange | undefined) => {
+    setRange(selectedRange)
+    if (selectedRange?.from && selectedRange?.to) {
+      onRangeChange({ start: selectedRange.from, end: selectedRange.to })
+      setLabel(
+        `${format(selectedRange.from, 'yyyy-MM-dd')} ~ ${format(selectedRange.to, 'yyyy-MM-dd')}`
+      )
+      setPopoverOpen(false) // 選擇完畢後關閉
+    }
+  }
+
+  return (
+    <Popover.Root open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" className={styles.triggerButton}>
+            <span>{label}</span>
+            <CalendarIcon size={16} className={styles.calendarIcon} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={() => handlePresetSelect('7d')}>最近 7 天</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => handlePresetSelect('30d')}>最近 30 天</DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => handlePresetSelect('season')}>本賽季</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <Popover.Trigger asChild>
+            {/* onSelect 需 preventDefault 以免觸發 DropdownMenu 的關閉事件 */}
+            <DropdownMenuItem onSelect={(e) => e.preventDefault()}>自訂範圍...</DropdownMenuItem>
+          </Popover.Trigger>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Popover.Portal>
+        <Popover.Content className={styles.dayPicker} sideOffset={5} align="start">
+          <DayPicker
+            mode="range"
+            defaultMonth={range?.from}
+            selected={range}
+            onSelect={handleCustomRangeSelect}
+            numberOfMonths={2}
+          />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  )
+}

--- a/components/features/StatsTrendChart.css.tsx
+++ b/components/features/StatsTrendChart.css.tsx
@@ -1,39 +1,18 @@
-import { style, globalStyle } from '@vanilla-extract/css'
+// /components/features/StatsTrendChart.css.ts
 
-/**
- * 圖表外層容器的樣式
- */
+import { style } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
 export const chartContainer = style({
   width: '100%',
-  maxWidth: '700px',
-  margin: '2rem auto',
-  padding: '1.5rem',
-  border: '1px solid #e2e8f0',
-  borderRadius: '12px',
-  backgroundColor: '#ffffff',
-  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+  height: '400px',
+  fontFamily: vars.fontFamily.body,
 })
 
-/**
- * Recharts Tooltip 的外層 Wrapper。
- * 我們只定義一個空的 class name，並使用 globalStyle 來覆寫 Recharts 的預設樣式。
- */
-export const tooltipWrapper = style({})
-
-// Recharts 的 Tooltip 預設 class name 是 .recharts-default-tooltip
-// 我們使用 globalStyle 來選取並設定其樣式。
-globalStyle(`${tooltipWrapper} .recharts-default-tooltip`, {
-  backgroundColor: 'rgba(255, 255, 255, 0.9) !important',
-  backdropFilter: 'blur(4px)',
-  border: '1px solid #d1d5db !important',
-  borderRadius: '8px !important',
-  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15) !important',
-  padding: '0.5rem 1rem !important',
-})
-
-// Tooltip 內容標籤的樣式
-globalStyle(`${tooltipWrapper} .recharts-tooltip-label`, {
-  fontWeight: 'bold',
-  color: '#1f2937',
-  marginBottom: '0.5rem !important',
+export const tooltipWrapper = style({
+  backgroundColor: vars.colors.surface,
+  border: `1px solid ${vars.colors.border}`,
+  borderRadius: '8px',
+  padding: `${vars.space.xs} ${vars.space.sm}`,
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
 })

--- a/components/features/StatsTrendChart.tsx
+++ b/components/features/StatsTrendChart.tsx
@@ -13,8 +13,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 
-// 假設樣式檔案也已更名或調整，此處暫時註解
-// import { chartContainer, tooltipWrapper } from './StatsTrendChart.css'
+import { chartContainer, tooltipWrapper } from './StatsTrendChart.css'
 
 // --- 型別定義 ---
 // 新的數據點型別，適用於趨勢圖
@@ -49,7 +48,8 @@ export const StatsTrendChart = ({
         height: 400,
         maxWidth: '800px',
         margin: '0 auto',
-      }} /* className={chartContainer} */
+      }}
+      className={chartContainer}
     >
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
@@ -68,7 +68,7 @@ export const StatsTrendChart = ({
           {/* Y 軸 */}
           <YAxis />
           {/* 滑鼠懸停時的提示框 */}
-          <Tooltip /* wrapperClassName={tooltipWrapper} */ />
+          <Tooltip wrapperClassName={tooltipWrapper} />
           {/* 圖例 */}
           <Legend />
           {/* 主要的數據曲線 */}

--- a/components/features/StatsTrendChart.tsx
+++ b/components/features/StatsTrendChart.tsx
@@ -1,5 +1,6 @@
+// /components/features/StatsTrendChart.tsx
+
 'use client'
-// components/features/StatsTrendChart.tsx
 
 import React from 'react'
 import {
@@ -12,73 +13,91 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
-
+import { MetricConfig } from '@/lib/configs/metrics'
 import { chartContainer, tooltipWrapper } from './StatsTrendChart.css'
 
 // --- 型別定義 ---
-// 新的數據點型別，適用於趨勢圖
-interface TrendDataPoint {
-  /** X 軸的標籤，通常是日期或時間 */
-  date: string
-  /** Y 軸的數值 */
-  value: number
+interface StatsTrendChartProps {
+  /**
+   * 圖表要呈現的數據陣列。
+   * 每個物件的 key 應對應 MetricConfig 中的 key。
+   * e.g., [{ date: '...', hits: 10, ops: 0.9 }]
+   */
+  data: Record<string, unknown>[]
+  /**
+   * 要在此圖表中顯示的指標設定陣列。
+   */
+  metrics: MetricConfig[]
 }
 
-interface StatsTrendChartProps {
-  /** 圖表要呈現的數據陣列 */
-  data: TrendDataPoint[]
-  /** 在圖例中顯示的數據線名稱 */
-  dataKeyName?: string
-}
+// 為不同的線條預先定義一組顏色
+const LINE_COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F']
 
 /**
- * StatsTrendChart 元件
- * @description 一個使用 Recharts 建立的曲線圖，用於視覺化呈現數據隨時間的趨勢。
- * @param {StatsTrendChartProps} props - 元件的 props
- * @returns {React.ReactElement}
+ * StatsTrendChart 元件 (增強版)
+ * @description 一個使用 Recharts 建立的動態曲線圖，支援多數據、多Y軸。
  */
-export const StatsTrendChart = ({
-  data,
-  dataKeyName = '數值',
-}: StatsTrendChartProps): React.ReactElement => {
+export const StatsTrendChart = ({ data, metrics }: StatsTrendChartProps): React.ReactElement => {
+  // 找出左右Y軸各自的第一個指標，以其顏色作為Y軸標籤顏色，建立視覺關聯
+  const leftAxisMetric = metrics.find((m) => m.yAxisId === 'left')
+  const rightAxisMetric = metrics.find((m) => m.yAxisId === 'right')
+
+  const getMetricColor = (metricKey: string) => {
+    const index = metrics.findIndex((m) => m.key === metricKey)
+    return LINE_COLORS[index % LINE_COLORS.length]
+  }
+
   return (
-    <div
-      style={{
-        width: '100%',
-        height: 400,
-        maxWidth: '800px',
-        margin: '0 auto',
-      }}
-      className={chartContainer}
-    >
+    <div className={chartContainer}>
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart
-          data={data}
-          margin={{
-            top: 5,
-            right: 30,
-            left: 20,
-            bottom: 5,
-          }}
-        >
-          {/* 圖表的網格線 */}
-          <CartesianGrid strokeDasharray="3 3" />
-          {/* X 軸，顯示日期 */}
-          <XAxis dataKey="date" />
-          {/* Y 軸 */}
-          <YAxis />
-          {/* 滑鼠懸停時的提示框 */}
-          <Tooltip wrapperClassName={tooltipWrapper} />
-          {/* 圖例 */}
-          <Legend />
-          {/* 主要的數據曲線 */}
-          <Line
-            type="monotone"
-            dataKey="value"
-            name={dataKeyName}
-            stroke="#8884d8"
-            activeDot={{ r: 8 }}
+        <LineChart data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+          <XAxis dataKey="date" stroke="#666" />
+
+          {/* 左側 Y 軸 */}
+          {leftAxisMetric && (
+            <YAxis
+              yAxisId="left"
+              stroke={getMetricColor(leftAxisMetric.key)}
+              tickFormatter={(value) => leftAxisMetric.formatter(value)}
+            />
+          )}
+
+          {/* 右側 Y 軸 */}
+          {rightAxisMetric && (
+            <YAxis
+              yAxisId="right"
+              orientation="right"
+              stroke={getMetricColor(rightAxisMetric.key)}
+              tickFormatter={(value) => rightAxisMetric.formatter(value)}
+            />
+          )}
+
+          <Tooltip
+            wrapperClassName={tooltipWrapper}
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            formatter={(value: number, name: string, props) => {
+              // 從 metrics 設定中找到對應的格式化函式
+              const metric = metrics.find((m) => m.label === name)
+              return metric ? metric.formatter(value) : String(value)
+            }}
           />
+
+          <Legend />
+
+          {/* 根據 metrics 設定動態生成 Line 元件 */}
+          {metrics.map((metric) => (
+            <Line
+              key={metric.key}
+              type="monotone"
+              dataKey={metric.key}
+              name={metric.label}
+              stroke={getMetricColor(metric.key)}
+              yAxisId={metric.yAxisId}
+              dot={false}
+              activeDot={{ r: 6 }}
+            />
+          ))}
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/components/ui/DataTable.css.ts
+++ b/components/ui/DataTable.css.ts
@@ -1,0 +1,58 @@
+// /components/ui/DataTable.css.ts
+
+import { style } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
+export const tableContainer = style({
+  width: '100%',
+  overflowX: 'auto',
+  border: `1px solid ${vars.colors.border}`,
+  borderRadius: '8px',
+  backgroundColor: vars.colors.surface,
+})
+
+export const table = style({
+  width: '100%',
+  minWidth: '600px', // 確保在小螢幕上內容不會過度壓縮，觸發滾動
+  borderCollapse: 'collapse',
+  textAlign: 'left',
+  fontFamily: vars.fontFamily.body,
+})
+
+export const thead = style({
+  backgroundColor: vars.colors.background,
+  borderBottom: `2px solid ${vars.colors.border}`,
+})
+
+export const th = style({
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  fontWeight: 600,
+  fontSize: vars.fontSizes.sm,
+  color: vars.colors.textSecondary,
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+  whiteSpace: 'nowrap',
+})
+
+export const tbody = style({})
+
+export const tr = style({
+  borderBottom: `1px solid ${vars.colors.border}`,
+  selectors: {
+    '&:last-child': {
+      borderBottom: 'none',
+    },
+    '&:hover': {
+      backgroundColor: vars.colors.background,
+    },
+  },
+  transition: 'background-color 0.15s ease-in-out',
+})
+
+export const td = style({
+  padding: `${vars.space.sm} ${vars.space.md}`,
+  fontSize: vars.fontSizes.base,
+  color: vars.colors.textPrimary,
+  verticalAlign: 'middle',
+  whiteSpace: 'nowrap',
+})

--- a/components/ui/DataTable.tsx
+++ b/components/ui/DataTable.tsx
@@ -1,0 +1,73 @@
+// /components/ui/DataTable.tsx
+
+'use client'
+
+import * as React from 'react'
+import * as styles from './DataTable.css'
+
+/**
+ * 通用 DataTable 的欄位定義型別。
+ * @template TData - 資料列的物件型別。
+ */
+export interface ColumnDef<TData> {
+  /** 用於從資料列物件中取值的 key。 */
+  accessorKey: keyof TData | (string & {})
+  /** 顯示在表頭的文字。 */
+  header: string
+  /** (可選) 自訂儲存格的渲染函式。 */
+  cell?: (props: { row: TData }) => React.ReactNode
+}
+
+/**
+ * 通用 DataTable 的 props 型別。
+ * @template TData - 資料列的物件型別。
+ */
+interface DataTableProps<TData> {
+  /** 要顯示的資料陣列。 */
+  data: TData[]
+  /** 欄位定義陣列。 */
+  columns: ColumnDef<TData>[]
+}
+
+/**
+ * 一個可複用的、由 props 驅動的通用數據表格元件。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function DataTable<TData extends Record<string, any>>({
+  data,
+  columns,
+}: DataTableProps<TData>) {
+  return (
+    // RWD 方案：在容器上啟用水平滾動。
+    // 未來可優化方案：在小螢幕上將每一行轉換為卡片式佈局 (Card-based layout)。
+    <div className={styles.tableContainer}>
+      <table className={styles.table}>
+        <thead className={styles.thead}>
+          <tr>
+            {columns.map((column, index) => (
+              <th key={index} className={styles.th}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className={styles.tbody}>
+          {data.map((row, rowIndex) => (
+            <tr key={rowIndex} className={styles.tr}>
+              {columns.map((column, colIndex) => {
+                const value = row[column.accessorKey as keyof TData]
+                return (
+                  <td key={colIndex} className={styles.td}>
+                    {column.cell ? column.cell({ row }) : String(value ?? '')}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+DataTable.displayName = 'DataTable'

--- a/hooks/useGetGames.ts
+++ b/hooks/useGetGames.ts
@@ -20,10 +20,11 @@ export type Game = NonNullable<GamesResponse>[number]
 export const useGetGames = (gameDate: string) => {
   return useQuery<Game[]>({
     // queryKey 包含 gameDate，確保不同日期的查詢會被獨立快取
-    queryKey: ['games', gameDate], // 呼叫符合 API 規格的端點
-
-    queryFn: () => apiClient<Game[]>(`games/${gameDate}`), // 只有在 gameDate 有值的時候才執行查詢
-
+    queryKey: ['games', gameDate],
+    queryFn: () => apiClient.get<Game[]>(`games/${gameDate}`),
+    // 只有在 gameDate 有值的時候才執行查詢
     enabled: !!gameDate,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   })
 }

--- a/hooks/useGetGamesToday.ts
+++ b/hooks/useGetGamesToday.ts
@@ -30,7 +30,8 @@ export type PlayerSummary = NonNullable<Game['player_summaries']>[number]
 export const useGetTodayDashboard = () => {
   return useQuery<DashboardResponse>({
     queryKey: ['dashboard', 'today'],
-    queryFn: () => apiClient<DashboardResponse>('dashboard/today'),
-    staleTime: 1000 * 60 * 5, // 儀表板資訊 5 分鐘內有效
+    queryFn: () => apiClient.get<DashboardResponse>('dashboard/today'),
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   })
 }

--- a/hooks/useGetPlayersSeasonStats.ts
+++ b/hooks/useGetPlayersSeasonStats.ts
@@ -1,0 +1,55 @@
+// /hooks/useGetPlayersSeasonStats.ts
+
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '@/lib/apiClient'
+import type { operations } from '@/types/generated-api'
+
+// 從 generated-api.ts 精確推斷出 API 回應的型別
+type GetPlayerStatsHistoryResponse =
+  operations['get_player_stats_history_api_players_stats_history_get']['responses']['200']['content']['application/json']
+
+interface UseGetPlayersSeasonStatsParams {
+  playerNames: string[]
+  dateRange: {
+    start: Date | null
+    end: Date | null
+  }
+}
+
+/**
+ * 格式化 Date 物件為 'YYYY-MM-DD' 字串。
+ * @param date - Date 物件
+ * @returns 'YYYY-MM-DD' 格式的字串，如果傳入 null 或 undefined 則回傳 null。
+ */
+const formatDate = (date: Date | null | undefined): string | null => {
+  if (!date) return null
+  // toISOString() 會產生 'YYYY-MM-DDTHH:mm:ss.sssZ'，我們僅需要日期部分。
+  return date.toISOString().split('T')[0]
+}
+
+/**
+ * 獲取多位球員在指定日期範圍內的賽季統計數據。
+ * @param params - 包含球員名稱陣列和日期範圍的物件。
+ */
+export const useGetPlayersSeasonStats = ({
+  playerNames,
+  dateRange,
+}: UseGetPlayersSeasonStatsParams) => {
+  return useQuery({
+    queryKey: ['playersSeasonStats', playerNames, dateRange],
+    queryFn: async () => {
+      const formattedStartDate = formatDate(dateRange.start)
+      const formattedEndDate = formatDate(dateRange.end)
+
+      return apiClient.get<GetPlayerStatsHistoryResponse>('/players/stats/history', {
+        params: {
+          player_name: playerNames,
+          start_date: formattedStartDate,
+          end_date: formattedEndDate,
+        },
+      })
+    },
+    // 只有當 playerNames 陣列不為空時才執行查詢
+    enabled: playerNames.length > 0,
+  })
+}

--- a/hooks/useGetPlayersSeasonStats.ts
+++ b/hooks/useGetPlayersSeasonStats.ts
@@ -51,5 +51,7 @@ export const useGetPlayersSeasonStats = ({
     },
     // 只有當 playerNames 陣列不為空時才執行查詢
     enabled: playerNames.length > 0,
+    refetchOnWindowFocus: false,
+    staleTime: Infinity,
   })
 }

--- a/hooks/useGetPlayersSeasonStats.ts
+++ b/hooks/useGetPlayersSeasonStats.ts
@@ -53,5 +53,6 @@ export const useGetPlayersSeasonStats = ({
     enabled: playerNames.length > 0,
     refetchOnWindowFocus: false,
     staleTime: Infinity,
+    placeholderData: (prev) => prev,
   })
 }

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,30 @@
+// /hooks/useIsMobile.ts
+
+'use client'
+
+import { useState, useEffect } from 'react'
+
+/**
+ * 一個 SSR-safe 的 Hook，用於偵測當前視窗寬度是否小於指定的斷點。
+ * @param breakpoint - 斷點值，預設為 768px。
+ * @returns boolean - 如果當前寬度小於斷點，則回傳 true。
+ */
+export const useIsMobile = (breakpoint = 768): boolean => {
+  // 預設為 false 以避免 SSR 與客戶端渲染不匹配的問題
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    // useEffect 只在客戶端執行，因此可以安全地存取 window 物件
+    const checkScreenSize = () => {
+      setIsMobile(window.innerWidth < breakpoint)
+    }
+
+    checkScreenSize() // 在元件掛載後立即執行一次檢查
+    window.addEventListener('resize', checkScreenSize)
+
+    // 在元件卸載時清除事件監聽器
+    return () => window.removeEventListener('resize', checkScreenSize)
+  }, [breakpoint])
+
+  return isMobile
+}

--- a/lib/configs/metrics.ts
+++ b/lib/configs/metrics.ts
@@ -1,0 +1,134 @@
+// /lib/configs/metrics.ts
+
+/**
+ * 定義單一數據指標的設定結構
+ */
+export interface MetricConfig {
+  /**
+   * 對應 PlayerSeasonStatsHistory 中的 key
+   */
+  key:
+    | 'hits'
+    | 'homeruns'
+    | 'rbi'
+    | 'runs_scored'
+    | 'strikeouts'
+    | 'walks'
+    | 'stolen_bases'
+    | 'total_bases'
+    | 'avg'
+    | 'obp'
+    | 'slg'
+    | 'ops'
+  /**
+   * 在 UI 上顯示的名稱
+   */
+  label: string
+  /**
+   * 數據類型，用於分組或特殊處理
+   */
+  type: 'cumulative' | 'ratio'
+  /**
+   * 對應圖表的 Y 軸 ID，用於多Y軸顯示
+   * 'left' 用於計數型數據 (如: 安打)，'right' 用於比率型數據 (如: 打擊率)
+   */
+  yAxisId: 'left' | 'right'
+  /**
+   * 格式化數值的函式，用於 Tooltip 或 Y 軸標籤
+   * @param value - 原始數值
+   * @returns 格式化後的字串
+   */
+  formatter: (value: number | null | undefined) => string
+}
+
+/**
+ * 可供賽季趨勢圖表選擇的所有數據指標設定
+ */
+export const PLAYER_STATS_METRICS: MetricConfig[] = [
+  // --- 每日比率型 ---
+  {
+    key: 'avg',
+    label: '打擊率 (AVG)',
+    type: 'ratio',
+    yAxisId: 'right',
+    formatter: (value) => (value ? value.toFixed(3) : '.000'),
+  },
+  {
+    key: 'ops',
+    label: '攻擊指數 (OPS)',
+    type: 'ratio',
+    yAxisId: 'right',
+    formatter: (value) => (value ? value.toFixed(3) : '.000'),
+  },
+  {
+    key: 'obp',
+    label: '上壘率 (OBP)',
+    type: 'ratio',
+    yAxisId: 'right',
+    formatter: (value) => (value ? value.toFixed(3) : '.000'),
+  },
+  {
+    key: 'slg',
+    label: '長打率 (SLG)',
+    type: 'ratio',
+    yAxisId: 'right',
+    formatter: (value) => (value ? value.toFixed(3) : '.000'),
+  },
+  // --- 累積計數型 ---
+  {
+    key: 'hits',
+    label: '安打 (H)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'homeruns',
+    label: '全壘打 (HR)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'rbi',
+    label: '打點 (RBI)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'runs_scored',
+    label: '得分 (R)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'strikeouts',
+    label: '三振 (SO)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'walks',
+    label: '保送 (BB)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'stolen_bases',
+    label: '盜壘 (SB)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+  {
+    key: 'total_bases',
+    label: '壘打數 (TB)',
+    type: 'cumulative',
+    yAxisId: 'left',
+    formatter: (value) => String(value ?? 0),
+  },
+]

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,6 @@
+// /lib/constants.ts
+
+/**
+ * 用於「賽季趨勢」頁面的預設目標球員名單。
+ */
+export const TRENDING_PLAYERS: string[] = ['王柏融', '吳念庭', '魔鷹']

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,17 @@
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tanstack/react-query": "^5.85.0",
         "@vanilla-extract/css": "^1.17.4",
         "@vanilla-extract/recipes": "^0.5.7",
+        "date-fns": "^4.1.0",
+        "lucide-react": "^0.540.0",
         "next": "15.4.6",
         "react": "19.1.0",
+        "react-day-picker": "^9.9.0",
         "react-dom": "19.1.0",
         "recharts": "^3.1.2",
         "zustand": "^5.0.7"
@@ -555,6 +559,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -2302,6 +2312,147 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5988,6 +6139,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -8663,6 +8830,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
+    "node_modules/lucide-react": {
+      "version": "0.540.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
+      "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -9604,6 +9780,27 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.9.0.tgz",
+      "integrity": "sha512-NtkJbuX6cl/VaGNb3sVVhmMA6LSMnL5G3xNL+61IyoZj0mUZFWTg4hmj7PHjIQ8MXN9dHWhUHFoJWG6y60DKSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-docgen-typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cpbl_takao_today_fe",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-popover": "^1.1.15",
@@ -2080,6 +2081,66 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,17 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@tanstack/react-query": "^5.85.0",
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/recipes": "^0.5.7",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.540.0",
     "next": "15.4.6",
     "react": "19.1.0",
+    "react-day-picker": "^9.9.0",
     "react-dom": "19.1.0",
     "recharts": "^3.1.2",
     "zustand": "^5.0.7"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "*.{js,jsx,ts,tsx,json,css,md}": "prettier --write"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-popover": "^1.1.15",

--- a/types/generated-api.ts
+++ b/types/generated-api.ts
@@ -44,7 +44,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/api/players/{player_name}/stats/history': {
+  '/api/players/stats/history': {
     parameters: {
       query?: never
       header?: never
@@ -53,9 +53,11 @@ export interface paths {
     }
     /**
      * Get Player Stats History
-     * @description 獲取指定球員的球季數據歷史紀錄，支援日期篩選與分頁。
+     * @description 獲取指定**一個或多個**球員的球季數據歷史紀錄，支援日期篩選。
+     *
+     *     回傳格式為一個字典，key 為球員姓名，value 為該球員的數據歷史列表。
      */
-    get: operations['get_player_stats_history_api_players__player_name__stats_history_get']
+    get: operations['get_player_stats_history_api_players_stats_history_get']
     put?: never
     post?: never
     delete?: never
@@ -838,20 +840,16 @@ export interface operations {
       }
     }
   }
-  get_player_stats_history_api_players__player_name__stats_history_get: {
+  get_player_stats_history_api_players_stats_history_get: {
     parameters: {
-      query?: {
+      query: {
+        /** @description 要查詢的一個或多個球員姓名 */
+        player_name: string[]
         start_date?: string | null
         end_date?: string | null
-        /** @description 要跳過的紀錄數量 */
-        skip?: number
-        /** @description 每頁回傳的最大紀錄數量 */
-        limit?: number
       }
       header?: never
-      path: {
-        player_name: string
-      }
+      path?: never
       cookie?: never
     }
     requestBody?: never
@@ -862,7 +860,9 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['PlayerSeasonStatsHistory'][]
+          'application/json': {
+            [key: string]: components['schemas']['PlayerSeasonStatsHistory'][]
+          }
         }
       }
       /** @description Validation Error */


### PR DESCRIPTION
摘要 (Summary)

此 PR 引入了全新的「賽季趨勢」頁面 (/season-trends)。該頁面提供了一個互動式儀表板，讓使用者可以視覺化地追蹤和比較球員在指定賽季時間範圍內的各項打擊數據表現。

本次開發採用了模組化和設定驅動的架構，建立了多個可複用的底層元件，確保了未來的可維護性和擴展性。

實作細節 (Implementation Details)

資料層建立 (Data Layer)

增強了通用 apiClient，使其支援陣列形式的查詢參數。

建立了 useGetPlayersSeasonStats 自訂 Hook，用於從後端獲取球員歷史數據。

通用元件與 Hook (Generic Components & Hooks)

<DataTable />: 建立了一個位於 /components/ui 的高度可複用數據表格元件。

useIsMobile: 建立了一個位於 /hooks 的 SSR-safe Hook，用於偵測行動裝置尺寸。

設定驅動架構 (Configuration-Driven Architecture)

建立了 /lib/configs/metrics.ts 指標設定檔，集中管理所有圖表指標。

功能元件增強 (Feature Component Enhancement)

<StatsTrendChart />: 重構圖表元件，使其支援多數據曲線與左右雙 Y 軸顯示。

頁面組裝與 RWD (Page Assembly & RWD)

在 /app/season-trends 路由下組裝了頁面，整合所有狀態管理與 UI 控制器。

實現了可摺疊的詳細數據表格。

完成了響應式設計，確保在桌面和行動裝置上的可用性。

後續修正與優化 (Follow-up Fixes & Optimizations)
在初步功能完成後，進行了多項除錯與體驗優化：

修正圖表渲染: 解決了 StatsTrendChart 因 dataKey 不匹配 (date vs data_retrieved_date) 而無法繪製曲線的問題。

優化查詢行為:

在 useGetPlayersSeasonStats 中設定 refetchOnWindowFocus: false，避免了切換視窗時不必要的 API 請求。

加入 staleTime 和 placeholderData，徹底解決了在切換日期等篩選條件時，頁面因 isLoading 觸發而閃爍的問題。

改善載入 UX:

利用 isFetching 狀態，將背景數據更新時的 UI 從「全螢幕載入」優化為「在原內容上顯示載入遮罩」，提供了更流暢的互動體驗。