### PR TITLE
feat(ui): 實作全站響應式導覽列

### DIFF
--- a/components/ui/Icons.tsx
+++ b/components/ui/Icons.tsx
@@ -1,4 +1,4 @@
-// components/ui/Icons.tsx
+// /components/ui/Icons.tsx
 
 import React from 'react'
 
@@ -37,5 +37,46 @@ export const ChevronRight = () => (
     strokeLinejoin="round"
   >
     <path d="m9 18 6-6-6-6" />
+  </svg>
+)
+
+/**
+ * 漢堡選單圖示。
+ */
+export const Menu = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <line x1="4" x2="20" y1="12" y2="12" />
+    <line x1="4" x2="20" y1="6" y2="6" />
+    <line x1="4" x2="20" y1="18" y2="18" />
+  </svg>
+)
+
+/**
+ * 關閉 (X) 圖示。
+ */
+export const X = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
   </svg>
 )

--- a/components/ui/Navbar.css.ts
+++ b/components/ui/Navbar.css.ts
@@ -1,13 +1,116 @@
-// components/ui/Navbar.css.ts
+// /components/ui/Navbar.css.ts
 
-import { style } from '@vanilla-extract/css'
+import { style, styleVariants } from '@vanilla-extract/css'
 import { vars } from '@/styles/theme.css'
 
-export const navContainer = style({
-  backgroundColor: vars.colors.surface,
-  padding: `${vars.space.md} ${vars.space.xl}`,
-  borderBottom: `1px solid ${vars.colors.border}`,
+const baseContainer = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  height: '60px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  padding: `0 ${vars.space.md}`,
+  backgroundColor: vars.colors.surface,
+  borderBottom: `1px solid ${vars.colors.border}`,
+  zIndex: vars.zIndices.navbar,
+})
+
+export const navContainer = style([baseContainer])
+
+export const titleLink = style({
+  fontSize: vars.fontSizes.lg,
+  fontWeight: 700,
+  color: vars.colors.textPrimary,
+  textDecoration: 'none',
+})
+
+export const menuButton = style({
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: vars.space.xs,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: vars.colors.textPrimary,
+})
+
+const baseDropdown = style({
+  position: 'absolute',
+  top: '60px', // Navbar height
+  left: 0,
+  right: 0,
+  backgroundColor: vars.colors.surface,
+  borderBottom: `1px solid ${vars.colors.border}`,
+  padding: `${vars.space.sm} 0`,
+  transition: 'transform 0.3s ease-in-out, opacity 0.3s ease-in-out',
+  zIndex: vars.zIndices.dropdown,
+})
+
+export const dropdownMenu = styleVariants({
+  open: [
+    baseDropdown,
+    {
+      transform: 'translateY(0)',
+      opacity: 1,
+      visibility: 'visible',
+    },
+  ],
+  closed: [
+    baseDropdown,
+    {
+      transform: 'translateY(-10px)',
+      opacity: 0,
+      visibility: 'hidden',
+    },
+  ],
+})
+
+export const menuList = style({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+})
+
+export const menuLink = style({
+  display: 'block',
+  padding: `${vars.space.md} ${vars.space.lg}`,
+  color: vars.colors.textPrimary,
+  textDecoration: 'none',
+  fontSize: vars.fontSizes.base,
+  transition: 'background-color 0.2s ease',
+  ':hover': {
+    backgroundColor: vars.colors.background,
+  },
+})
+
+const baseBackdrop = style({
+  position: 'fixed',
+  top: '60px', // Start below the navbar
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  zIndex: vars.zIndices.backdrop,
+  transition: 'opacity 0.3s ease-in-out',
+})
+
+export const backdrop = styleVariants({
+  open: [
+    baseBackdrop,
+    {
+      opacity: 1,
+      visibility: 'visible',
+    },
+  ],
+  closed: [
+    baseBackdrop,
+    {
+      opacity: 0,
+      visibility: 'hidden',
+    },
+  ],
 })

--- a/components/ui/Navbar.tsx
+++ b/components/ui/Navbar.tsx
@@ -1,3 +1,74 @@
+// /components/ui/Navbar.tsx
+
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { Menu, X } from '@/components/ui/Icons'
+import * as styles from './Navbar.css'
+
+const navLinks = [
+  { href: '/season-trends', label: '賽季趨勢' },
+  { href: '/advanced-analysis', label: '進階數據分析' },
+  { href: '/about', label: '關於本站' },
+]
+
 export const Navbar = () => {
-  return <h1>CPBL Stats</h1>
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleMenu = () => {
+    setIsOpen(!isOpen)
+  }
+
+  const closeMenu = () => {
+    setIsOpen(false)
+  }
+
+  // Effect to handle body scroll lock when menu is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'auto'
+    }
+
+    // Cleanup function to restore scroll on component unmount
+    return () => {
+      document.body.style.overflow = 'auto'
+    }
+  }, [isOpen])
+
+  return (
+    <header>
+      <div
+        className={styles.backdrop[isOpen ? 'open' : 'closed']}
+        onClick={closeMenu}
+        aria-hidden="true"
+      />
+      <nav className={styles.navContainer}>
+        <Link href="/" className={styles.titleLink} onClick={closeMenu}>
+          CPBL Stats
+        </Link>
+        <button
+          className={styles.menuButton}
+          onClick={toggleMenu}
+          aria-expanded={isOpen}
+          aria-label="Toggle navigation menu"
+        >
+          {isOpen ? <X /> : <Menu />}
+        </button>
+        <div className={styles.dropdownMenu[isOpen ? 'open' : 'closed']}>
+          <ul className={styles.menuList}>
+            {navLinks.map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className={styles.menuLink} onClick={closeMenu}>
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </nav>
+    </header>
+  )
 }

--- a/styles/theme.css.ts
+++ b/styles/theme.css.ts
@@ -43,6 +43,12 @@ export const vars = createThemeContract({
     xl: null,
     xxl: null,
   },
+  zIndices: {
+    backdrop: null,
+    dropdown: null,
+    navbar: null,
+    modal: null,
+  },
 })
 
 // =================================================================
@@ -84,6 +90,12 @@ export const lightTheme = createTheme(vars, {
     xl: '20px',
     xxl: '24px',
   },
+  zIndices: {
+    backdrop: '900',
+    dropdown: '950',
+    navbar: '1000',
+    modal: '1100',
+  },
 })
 
 // =================================================================
@@ -124,5 +136,11 @@ export const darkTheme = createTheme(vars, {
     lg: '18px',
     xl: '20px',
     xxl: '24px',
+  },
+  zIndices: {
+    backdrop: '900',
+    dropdown: '950',
+    navbar: '1000',
+    modal: '1100',
   },
 })


### PR DESCRIPTION
摘要
本次 Pull Request 的核心目標是將原先僅作為 <h1> 佔位符的 Navbar 元件，全面升級為一個功能完整的全站響應式導覽列。此變更旨在建立網站的核心導覽機制，提升使用者在不同頁面間穿梭的便利性與體驗一致性。

新版導覽列包含漢堡選單、下拉式連結、平滑的開合動畫，以及防止頁面滾動的遮罩層等現代化網頁應用的標準功能。

主要變更
Navbar.tsx (元件邏輯)

狀態管理: 使用 useState hook (isOpen) 來管理選單的展開/收合狀態。

互動邏輯:

實作 toggleMenu 與 closeMenu 函式來控制選單狀態。

點擊漢堡/關閉圖示可切換選單開合。

點擊背景遮罩層或任一導覽連結時，會自動關閉選單。

副作用處理: 透過 useEffect hook，在選單展開時禁止 <body> 捲動，避免背景內容滾動造成不良體驗，並在元件卸載時清除樣式。

條件渲染: 根據 isOpen 狀態，動態渲染 Menu 或 X 圖示，並切換下拉選單與遮罩層的 CSS class 以觸發動畫。

Navbar.css.ts (元件樣式)

固定定位: 使用 position: fixed 將導覽列固定於視窗頂部，確保其在頁面滾動時始終可見。

層級管理: 透過 theme.css.ts 中新增的 zIndices 變數，精確控制導覽列、下拉選單及遮罩層的堆疊順序。

過渡動畫: 為下拉選單的 transform 與 opacity 屬性，以及遮罩層的 opacity 屬性加上 transition，實現平滑流暢的開合動畫效果。

Icons.tsx (圖示庫)

新增 Menu (漢堡) 與 X (關閉) 兩個 SVG 圖示元件，供 Navbar 條件性地使用。

theme.css.ts (全域設計系統)

擴充設計契約: 在 createThemeContract 中新增 zIndices 屬性，建立全站統一的 z-index 管理規範。

實作主題變數: 於淺色與深色主題中提供 zIndices 的具體數值，解決了 TypeScript 型別檢查錯誤，並提升了樣式代碼的可維護性。

如何測試
啟動應用程式，導航至任一頁面。

驗證基本外觀：

應能在頁面最頂部看到一個固定的導覽列，左側為 "CPBL Stats" 標題，右側為一個漢堡圖示。

向下滾動頁面，確認導覽列始終保持在頂部。

驗證選單展開：

點擊右上角的漢堡圖示。

應能看到下拉選單平滑地從上方展開，同時頁面其餘部分被半透明黑色遮罩層覆蓋。

漢堡圖示應變為 "X" 圖示。

選單中應包含「賽季趨勢」、「進階數據分析」、「關於本站」三個連結。

驗證選單收合：

在選單展開狀態下，點擊 "X" 圖示，選單應平滑地收合。

再次展開選單，點擊黑色遮罩層區域，選單應同樣平滑地收合。

驗證連結導覽：

展開選單，點擊任一連結（例如「關於本站」）。

頁面應成功導航至對應路徑，且選單應在導航後自動收合。